### PR TITLE
Fix file handle leak

### DIFF
--- a/SmartLockServer.py
+++ b/SmartLockServer.py
@@ -258,8 +258,12 @@ def change_screen(self,screen_name):
 
 class HomeScreen(Screen):
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.MIFAREReader = MFRC522.MFRC522()
+    
     def readNFC(self,dt):
-        MIFAREReader = MFRC522.MFRC522()
+        MIFAREReader = self.MIFAREReader
 
         (status,TagType) = MIFAREReader.MFRC522_Request(MIFAREReader.PICC_REQIDL)
 


### PR DESCRIPTION
MFRC522 does not close file handles, constructor of MFRC522 will open the NFC reader each time, ultimately leading to file handles exhaustion on the system.

Only open the NFC reader once at start time.